### PR TITLE
Increment globalResults.errors when an expection is thrown from a test

### DIFF
--- a/lib/runner/run.js
+++ b/lib/runner/run.js
@@ -160,6 +160,7 @@ module.exports = new (function() {
           console.log(Logger.colors.red('\nAn error occurred while running the test:'));
           console.log(err.stack);
           testResults.errors++;
+          globalResults.errors++;
           client.terminate();
           error = true;
           afterCallback(err, testResults);


### PR DESCRIPTION
If the number of errors isn't incremented in globalResults, the error is reported but the test runner still exits with 0 indicating success.

An example of when this happens is when an error occurs during `setUp`.

The test will fail:

```
TEST FAILURE: 0 assertions failed, 0 passed. (56ms)
```

But the exit code is 0:

```
$ echo $?
0
```
